### PR TITLE
Set name for puppet resource netapp_qtree

### DIFF
--- a/lib/puppet/provider/netapp_qtree/cmode.rb
+++ b/lib/puppet/provider/netapp_qtree/cmode.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:netapp_qtree).provide(:cmode, :parent => Puppet::Provider::Ne
       secstyle = qtree_info.child_get_string("security-style")
 
       # Construct an export hash for rule
-      qtree_hash = { :qtname          => name,
+      qtree_hash = { :qtname        => name,
                      :mode          => mode,
                      :securitystyle => secstyle,
                      :ensure        => :present }
@@ -47,8 +47,10 @@ Puppet::Type.type(:netapp_qtree).provide(:cmode, :parent => Puppet::Provider::Ne
       # Add the volume details and title
       if qtree_info.child_get_string("volume").empty?
         qtree_hash[:volume] = ""
+        qtree_hash[:name] = qtree_hash[:qtname]
       else
         qtree_hash[:volume] = qtree_info.child_get_string("volume")
+        qtree_hash[:name] = "/#{qtree_hash[:volume]}/#{qtree_hash[:qtname]}"
       end
 
       Puppet.debug("Puppet::Provider::Netapp_qtree.cmode.prefetch: Volume for '#{name}' is '#{qtree_info.child_get_string("volume")}'.")


### PR DESCRIPTION
Eg:
```puppet
root@servicevm:~# FACTER_url=https://user:password@vsim-01/vserver01 puppet resource netapp_qtree
netapp_qtree { '/nfsvol/qtree1':
  ensure => 'present',
  qtname => 'qtree1',
  volume => 'nfsvol',
}
netapp_qtree { '/voltst11/test2':
  ensure => 'present',
  qtname => 'test2',
  volume => 'voltst11',
}
netapp_qtree { '/voltst11/testname':
  ensure => 'present',
  qtname => 'testname',
  volume => 'voltst11',
}
```